### PR TITLE
Update combine transitions from skills & extend path

### DIFF
--- a/hook!-full-game/src/Game.tscn
+++ b/hook!-full-game/src/Game.tscn
@@ -108,6 +108,11 @@ position = Vector2( 2610, 0 )
 [node name="Waypoints" parent="MovingPlatform" instance=ExtResource( 7 )]
 editor/display_folded = true
 position = Vector2( 2612.25, 3.375 )
+mode = 0
+editor_process = true
+line_color = Color( 0.228943, 0.710254, 0.945312, 1 )
+line_width = 10.0
+triangle_color = Color( 0.722656, 0.908997, 1, 1 )
 
 [node name="Node2D" type="Node2D" parent="MovingPlatform/Waypoints"]
 

--- a/hook!-full-game/src/Player/Player.gd
+++ b/hook!-full-game/src/Player/Player.gd
@@ -17,11 +17,14 @@ onready var _transitions: = {}
 
 
 func _ready() -> void:
-	# combine transitions from all skills
+	# combine transitions from all skills - union operation on Dictionaries
 	for skill in skills.get_children():
 		for key in skill.transitions:
 			if _transitions.has(key):
 				for state in skill.transitions[key]:
+					if state in _transitions[key]:
+						continue
+					
 					_transitions[key].push_back(state)
 			else:
 				_transitions[key] = skill.transitions[key]

--- a/hook!-full-game/src/Player/Player.tscn
+++ b/hook!-full-game/src/Player/Player.tscn
@@ -24,6 +24,8 @@ shape = SubResource( 1 )
 position = Vector2( 0, -30 )
 
 [node name="LedgeDetector" parent="." instance=ExtResource( 3 )]
+active = true
+ray_length = 30.0
 
 [node name="FloorDetector" parent="." instance=ExtResource( 4 )]
 

--- a/hook!-full-game/src/Player/Skills/Base.gd
+++ b/hook!-full-game/src/Player/Skills/Base.gd
@@ -1,4 +1,4 @@
-extends "Skill.gd"
+extends "res://src/Player/Skills/Skill.gd"
 
 
 const FLOOR_NORMAL: = Vector2(0, -1)

--- a/hook!-full-game/src/Player/Skills/Dash.gd
+++ b/hook!-full-game/src/Player/Skills/Dash.gd
@@ -1,4 +1,4 @@
-extends "Skill.gd"
+extends "res://src/Player/Skills/Skill.gd"
 
 
 const DASH_RESET_TIME: = 0.2


### PR DESCRIPTION
I've updated the combine transitions algorithm in `Player` - now it's a *union* type of operation on all `transitions` dictionaries from `Skills`. Before it would add double transitions, so something like:

```
{ ...
"air": ["idle", "ledge", "idle"],
... }
```

could have been possible. Fixed so only unique transitions can be present.

Also changed the `extends` for `Player` `Skill`s to use *absolute* path since I was getting some errors in the console with `relative` path for some reason. It's not something that affects the game but it's still annoying.