### PR TITLE
Fix Wall State issues

### DIFF
--- a/hook!-full-game/src/Player/Player.gd
+++ b/hook!-full-game/src/Player/Player.gd
@@ -11,6 +11,7 @@ onready var skin: Position2D = $Skin
 onready var stats: Stats = $Stats
 onready var collider: CollisionShape2D = $CollisionShape2D
 onready var hitbox: Area2D = $HitBox
+onready var wall_detector: RayCast2D = $WallDetector
 
 const FLOOR_NORMAL: = Vector2.UP
 

--- a/hook!-full-game/src/Player/Player.tscn
+++ b/hook!-full-game/src/Player/Player.tscn
@@ -34,8 +34,15 @@ shape = SubResource( 1 )
 position = Vector2( 0, -30 )
 
 [node name="LedgeDetector" parent="." instance=ExtResource( 3 )]
+is_active = true
+ray_length = 30.0
 
 [node name="FloorDetector" parent="." instance=ExtResource( 4 )]
+
+[node name="WallDetector" type="RayCast2D" parent="."]
+position = Vector2( 0, -31.1111 )
+cast_to = Vector2( 100, 0 )
+collision_mask = 2
 
 [node name="CameraAnchorDetector" parent="." instance=ExtResource( 5 )]
 editor/display_folded = true
@@ -45,6 +52,10 @@ remote_path = NodePath("../../CameraRig")
 
 [node name="CameraRig" parent="." instance=ExtResource( 6 )]
 editor/display_folded = true
+
+[node name="ShakingCamera" parent="CameraRig" index="0"]
+DAMP_EASING = 1.0
+is_shaking = false
 
 [node name="Skin" parent="." instance=ExtResource( 7 )]
 
@@ -75,11 +86,14 @@ wait_time = 0.1
 one_shot = true
 
 [node name="Wall" type="Node" parent="StateMachine/Move"]
-editor/display_folded = true
 script = ExtResource( 13 )
 
 [node name="JumpDelay" type="Timer" parent="StateMachine/Move/Wall"]
 wait_time = 0.2
+one_shot = true
+
+[node name="FallDelay" type="Timer" parent="StateMachine/Move/Wall"]
+wait_time = 0.05
 one_shot = true
 
 [node name="Ledge" type="Node" parent="StateMachine"]

--- a/hook!-full-game/src/Player/States/Air.gd
+++ b/hook!-full-game/src/Player/States/Air.gd
@@ -27,7 +27,7 @@ func physics_process(delta: float) -> void:
 	elif owner.ledge_detector.is_against_ledge(sign(move.velocity.x)):
 		_state_machine.transition_to("Ledge", {move_state = move})
 	
-	if owner.is_on_wall():
+	if owner.is_on_wall() and move.velocity.y > 0:
 		var wall_normal: float = owner.get_slide_collision(0).normal.x
 		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": move.velocity})
 


### PR DESCRIPTION
Close #79 
Close #82 

And also fix a major issue where the WallState didn't connect the JumpDelay due to its `setup()` not being called, moved the signal connections to its `_ready()` instead so maybe the JumpDelay expected behavior now correctly happens.