### PR TITLE
Add PassThrough mechanic

### DIFF
--- a/hook!-full-game/project.godot
+++ b/hook!-full-game/project.godot
@@ -262,6 +262,7 @@ toggle_debug_menu={
 2d_physics/layer_1="Player"
 2d_physics/layer_2="World"
 2d_physics/layer_3="Hookable"
+2d_physics/layer_4="PassThrough"
 2d_physics/layer_6="CameraAnchor"
 2d_physics/layer_11="DamageSource"
 2d_physics/layer_12="Hitbox"

--- a/hook!-full-game/src/Player/PassThroughDetector.gd
+++ b/hook!-full-game/src/Player/PassThroughDetector.gd
@@ -1,0 +1,26 @@
+extends Area2D
+
+onready var _actor: KinematicBody2D = get_node(_actor_path)
+
+const PASS_THROUGH_LAYER = 3
+export var _actor_path: = NodePath("..")
+
+
+func _ready() -> void:
+	connect("body_exited", self, "_on_body_exited")
+
+
+func _physics_process(delta: float) -> void:
+	if _actor.is_on_floor() and not _actor.get_collision_mask_bit(PASS_THROUGH_LAYER):
+		_actor.set_collision_mask_bit(PASS_THROUGH_LAYER, true)
+
+
+func _on_body_exited(body: CollisionObject2D) -> void:
+	if not _actor.get_collision_mask_bit(PASS_THROUGH_LAYER):
+		_actor.set_collision_mask_bit(PASS_THROUGH_LAYER, true)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("jump"):
+		if Input.is_action_pressed("move_down"):
+			_actor.set_collision_mask_bit(PASS_THROUGH_LAYER, false)

--- a/hook!-full-game/src/Player/Player.tscn
+++ b/hook!-full-game/src/Player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://src/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://src/Player/Hook/Hook.tscn" type="PackedScene" id=2]
@@ -19,12 +19,16 @@
 [ext_resource path="res://src/Player/States/Stagger.gd" type="Script" id=17]
 [ext_resource path="res://src/Combat/Stats.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/Combat/HitBox/HitBox.tscn" type="PackedScene" id=19]
+[ext_resource path="res://src/Player/PassThroughDetector.gd" type="Script" id=20]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 30, 30 )
 
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 30, 30 )
+
 [node name="Player" type="KinematicBody2D"]
-collision_mask = 6
+collision_mask = 14
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -51,6 +55,10 @@ collision_mask = 2
 remote_path = NodePath("../../CameraRig")
 
 [node name="CameraRig" parent="." instance=ExtResource( 6 )]
+
+[node name="ShakingCamera" parent="CameraRig" index="0"]
+DAMP_EASING = 1.0
+is_shaking = false
 
 [node name="Skin" parent="." instance=ExtResource( 7 )]
 
@@ -110,6 +118,17 @@ one_shot = true
 
 [node name="HitBox" parent="." instance=ExtResource( 19 )]
 position = Vector2( 0, -30 )
+
+[node name="PassThroughDetector" type="Area2D" parent="."]
+position = Vector2( 0, -30 )
+collision_layer = 0
+collision_mask = 8
+script = ExtResource( 20 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PassThroughDetector"]
+rotation = 3.14159
+shape = SubResource( 2 )
+one_way_collision = true
 
 [editable path="CameraAnchorDetector"]
 

--- a/hook!-full-game/src/Player/States/Move.gd
+++ b/hook!-full-game/src/Player/States/Move.gd
@@ -36,7 +36,8 @@ func setup(player: KinematicBody2D, state_machine: Node) -> void:
 
 func unhandled_input(event: InputEvent) -> void:
 	if owner.is_on_floor() and event.is_action_pressed("jump"):
-		self.velocity = calculate_velocity(velocity, speed, Vector2(0.0, JUMP_SPEED), 1.0, Vector2.UP)
+		if not Input.is_action_pressed("move_down"):
+			self.velocity = calculate_velocity(velocity, speed, Vector2(0.0, JUMP_SPEED), 1.0, Vector2.UP)
 		_state_machine.transition_to("Move/Air")
 	if event.is_action_pressed('toggle_debug_move'):
 		_state_machine.transition_to('Debug')


### PR DESCRIPTION
Close #84
Fix #80 

Currently we need a second layer of TileMap that is only inside the PassThrough layer, but when we start using Platform objects it will become more intuitive.

During my tests, there weren't problems with the ledge detector, so I decided to not touch it.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/10171059/60627817-b4443d80-9dc5-11e9-8950-76bb7af7aaf3.gif)

I recommend cleaning up the extra testing levels I'm creating :P