### PR TITLE
Added configuration warnings

### DIFF
--- a/hook!-full-game/src/AI/PatrolAgent.gd
+++ b/hook!-full-game/src/AI/PatrolAgent.gd
@@ -94,3 +94,9 @@ func _draw() -> void:
 	var center: = (start + end) / 2
 	var angle: = start.angle_to(end)
 	DrawingUtils.draw_triangle(self, center, angle, draw_radius)
+
+func _get_configuration_warning() -> String:
+	var warning: = ""
+	if not $Start or not $End:
+		warning += "%s requires two Position2D children named Start and End to work." % name
+	return warning

--- a/hook!-full-game/src/Player/Camera/ShakingCamera.gd
+++ b/hook!-full-game/src/Player/Camera/ShakingCamera.gd
@@ -30,6 +30,10 @@ func _process(delta) -> void:
 		rand_range(amplitude, -amplitude) * damping)
 
 
+func _get_configuration_warning() -> String:
+	return "" if $Timer else "%s requires a Timer child named Timer" % name
+
+
 func set_duration(value: float) -> void:
 	duration = value
 	if timer:

--- a/hook!-full-game/src/Player/LedgeDetector.gd
+++ b/hook!-full-game/src/Player/LedgeDetector.gd
@@ -10,16 +10,14 @@ onready var ray_top: RayCast2D = $RayTop
 
 onready var _offset: float = ray_bottom.position.x
 
-export var is_active: = true setget set_is_active
+export var is_active: = true
 
 export var ray_length: = 30.0 setget set_ray_length
 
 var _ray_cast_to_x: = ray_length setget _set_ray_cast_to_x
-var _is_ready: = false
 
 
 func _ready() -> void:
-	_is_ready = true
 	self.ray_length = ray_length
 
 
@@ -34,15 +32,8 @@ func is_against_ledge(look_direction: int) -> bool:
 
 
 func set_ray_length(value: float) -> void:
-	if not _is_ready:
-		return
-	
 	ray_length = value
 	self._ray_cast_to_x = value * sign(_ray_cast_to_x)
-
-
-func set_is_active(value:bool) -> void:
-	is_active = value
 
 
 func _set_ray_cast_to_x(value: float) -> void:

--- a/hook!-full-game/src/Player/PassThroughDetector.gd
+++ b/hook!-full-game/src/Player/PassThroughDetector.gd
@@ -1,9 +1,10 @@
+tool
 extends Area2D
 
-onready var _actor: KinematicBody2D = get_node(_actor_path)
+onready var _actor: KinematicBody2D = get_node(actor_path)
 
 const PASS_THROUGH_LAYER = 3
-export var _actor_path: = NodePath("..")
+export var actor_path: = NodePath("..")
 
 
 func _ready() -> void:
@@ -11,7 +12,7 @@ func _ready() -> void:
 
 
 func _physics_process(delta: float) -> void:
-	if _actor.is_on_floor() and not _actor.get_collision_mask_bit(PASS_THROUGH_LAYER):
+	if not Engine.editor_hint and _actor.is_on_floor() and not _actor.get_collision_mask_bit(PASS_THROUGH_LAYER):
 		_actor.set_collision_mask_bit(PASS_THROUGH_LAYER, true)
 
 
@@ -24,3 +25,6 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("jump"):
 		if Input.is_action_pressed("move_down"):
 			_actor.set_collision_mask_bit(PASS_THROUGH_LAYER, false)
+
+func _get_configuration_warning() -> String:
+	return "Actor Path must be defined" if actor_path.is_empty() else ""

--- a/hook!-full-game/src/Player/States/Air.gd
+++ b/hook!-full-game/src/Player/States/Air.gd
@@ -1,3 +1,4 @@
+tool
 extends State
 
 
@@ -6,6 +7,10 @@ signal jumped
 onready var jump_delay: Timer = $JumpDelay
 
 const X_ACCELERATION: = 3000.0
+
+
+func _get_configuration_warning() -> String:
+	return "" if $JumpDelay else "%s requires a Timer child named JumpDelay" % name
 
 
 func unhandled_input(event: InputEvent) -> void:

--- a/hook!-full-game/src/Player/States/Idle.gd
+++ b/hook!-full-game/src/Player/States/Idle.gd
@@ -1,3 +1,4 @@
+tool
 extends State
 
 
@@ -8,6 +9,10 @@ func _setup() -> void:
 	# force update once at start of game
 	var move: = get_parent()
 	owner.move_and_slide(move.velocity, owner.FLOOR_NORMAL)
+
+
+func _get_configuration_warning() -> String:
+	return "" if $JumpDelay else "%s requires a Timer child named JumpDelay" % name
 
 
 func unhandled_input(event: InputEvent) -> void:

--- a/hook!-full-game/src/Player/States/Stagger.gd
+++ b/hook!-full-game/src/Player/States/Stagger.gd
@@ -1,6 +1,12 @@
+tool
 extends State
 
 onready var duration: Timer = $Duration
+
+
+func _get_configuration_warning() -> String:
+	return "" if $Duration else "%s requires a Timer child named Duration" % name
+
 
 func enter(msg: Dictionary = {}):
 	duration.start()

--- a/hook!-full-game/src/Player/States/Wall.gd
+++ b/hook!-full-game/src/Player/States/Wall.gd
@@ -1,3 +1,4 @@
+tool
 extends State
 
 onready var jump_delay: Timer = $JumpDelay
@@ -15,6 +16,10 @@ var _wall_normal: = -1
 func _ready() -> void:
 	jump_delay.connect("timeout", self, "_on_JumpDelay_timeout")
 	fall_delay.connect("timeout", self, "_on_FallDelay_timeout")
+
+
+func _get_configuration_warning() -> String:
+	return "" if $JumpDelay and $FallDelay else "%s requires two Timer children named JumpDelay and FallDelay" % name
 
 
 func enter(msg: Dictionary = {}) -> void:

--- a/hook!-full-game/src/UI/debug/DebugPanel.gd
+++ b/hook!-full-game/src/UI/debug/DebugPanel.gd
@@ -1,3 +1,4 @@
+tool
 extends Control
 """
 Displays the values of properties of a given node
@@ -31,6 +32,10 @@ func _setup() -> void:
 		track(property)
 
 
+func _get_configuration_warning() -> String:
+	return "" if not reference_path.is_empty() else "Reference Path should not be empty."
+
+
 func track(property: String) -> void:
 	var label: = Label.new()
 	label.autowrap = true
@@ -46,6 +51,8 @@ func _clear() -> void:
 
 
 func _update() -> void:
+	if Engine.editor_hint:
+		return
 	var search_array: Array = properties
 	for property in properties:
 		var label: Label = _container.get_child(search_array.find(property))


### PR DESCRIPTION
Only a few files changed as I wanted to know if this is more or less what is needed for #90 

Continuing the discussion that I started in the issue, that "bug" only happens when checking for script properties. In the `PatrolAgent` while checking for the `End` and `Start` nodes, the editor behaves as expected.

Also, I made some changes in the `LedgeDetector.gd`: it has an `_is_ready` property that is only used in its `set_ray_length` function. `_ray_length` is exported but as the flag is not set to true unless the game is running, it defeats the purpose of having an exported value. The setter for `is_active` wasn't needed as well. From what I tested everything is working as expected but feel free to revert the changes if need be.

ps: Not sure why the changes to `Hook.gd` "bled" in this commit, I stashed my changes and branched from master, which was clean. 