### PR TITLE
Fix plugin preventing panning

### DIFF
--- a/hook!-full-game/addons/level_design_dock/plugin.cfg
+++ b/hook!-full-game/addons/level_design_dock/plugin.cfg
@@ -3,5 +3,5 @@
 name="Level Design Dock"
 description="The FileSystem meets the Tilemap to easier the process of designing levels by instancing scenes just like painting tiles"
 author="Henrique \"Pigdev\" Campos"
-version="0.1.0"
+version="0.1.1"
 script="plugin.gd"

--- a/hook!-full-game/addons/level_design_dock/plugin.gd
+++ b/hook!-full-game/addons/level_design_dock/plugin.gd
@@ -31,7 +31,6 @@ func forward_canvas_gui_input(event: InputEvent) -> bool:
 	var forward: = false
 	if event is InputEventMouseMotion:
 		_move_instance()
-		forward = true
 	elif event is InputEventMouseButton:
 		if event.button_index == BUTTON_LEFT:
 			forward = true


### PR DESCRIPTION
I think this doesn't break the plugin's behavior as far as I could test, so it's fine to not consume the mouse motion in any case.

Close #107 