### PR TITLE
Fix redefinition of variables

### DIFF
--- a/hook!-full-game/src/Player/States/Hook.gd
+++ b/hook!-full-game/src/Player/States/Hook.gd
@@ -13,9 +13,6 @@ var velocity: = Vector2.ZERO setget set_velocity
 
 
 func physics_process(delta: float) -> void:
-	var to_target: Vector2 = target_global_position - owner.global_position
-	var distance: = to_target.length()
-	
 	self.velocity = Steering.arrive_to(
 		velocity,
 		owner.global_position,


### PR DESCRIPTION
The two variables in question were redefined making the game crash. Just deleted one set of definitions.