### PR TITLE
Add transition sequence for level load/change

### DIFF
--- a/hook!-full-game/project.godot
+++ b/hook!-full-game/project.godot
@@ -42,7 +42,7 @@ _global_script_classes=[ {
 "base": "Node2D",
 "class": "DrawingUtils",
 "language": "GDScript",
-"path": "res://src/Autoload/DrawingUtils.gd"
+"path": "res://src/Main/DrawingUtils.gd"
 }, {
 "base": "InterceptBehavior2D",
 "class": "EvadeBehavior2D",

--- a/hook!-full-game/src/Autoload/Events.gd
+++ b/hook!-full-game/src/Autoload/Events.gd
@@ -1,7 +1,6 @@
 extends Node
 
 
-signal level_loaded(level)
 signal player_info_updated(dict)
 signal player_state_changed(state)
 signal player_moved(player)

--- a/hook!-full-game/src/Autoload/LevelLoader.gd
+++ b/hook!-full-game/src/Autoload/LevelLoader.gd
@@ -3,6 +3,8 @@ extends Node
 Loads and unloads levels
 """
 
+onready var scene_tree: = get_tree()
+
 var _game: Node = null
 var _player: Player = null
 var _level: Node2D = null
@@ -18,6 +20,8 @@ func trigger(NewLevel: PackedScene) -> void:
 	_game.remove_child(_player)
 	
 	if _level:
+		scene_tree.paused = true
+		_game.transition.animation_player.play("transition")
 		_level.queue_free()
 		yield(_level, "tree_exited")
 
@@ -25,8 +29,11 @@ func trigger(NewLevel: PackedScene) -> void:
 
 	var player_spawn: = _level.get_node("Checkpoints").get_child(0)
 	_player.global_position = player_spawn.global_position
-
+	
+	if _game.transition.animation_player.current_animation == "transition":
+		yield(_game.transition, "peaked")
+	
 	_game.add_child(_level)
 	_game.add_child(_player)
 	
-	Events.emit_signal("level_loaded", _level)
+	scene_tree.paused = false

--- a/hook!-full-game/src/Main/Game.gd
+++ b/hook!-full-game/src/Main/Game.gd
@@ -1,5 +1,8 @@
 extends Node
 
+
+onready var transition: ColorRect = $UI/Transition
+
 export(PackedScene) var StartLevel: = preload("res://src/Levels/Level1.tscn")
 
 

--- a/hook!-full-game/src/Main/Game.tscn
+++ b/hook!-full-game/src/Main/Game.tscn
@@ -1,10 +1,57 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://src/Main/Game.gd" type="Script" id=1]
 [ext_resource path="res://assets/theme/gdquest.theme" type="Theme" id=2]
 [ext_resource path="res://src/UI/debug/DebugDock.gd" type="Script" id=3]
 [ext_resource path="res://src/UI/debug/DebugPanel.tscn" type="PackedScene" id=4]
-[ext_resource path="res://src/Player/Player.tscn" type="PackedScene" id=5]
+[ext_resource path="res://src/UI/Transition.gd" type="Script" id=5]
+[ext_resource path="res://src/Player/Player.tscn" type="PackedScene" id=6]
+
+[sub_resource type="Animation" id=1]
+resource_name = "<BASE>"
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ) ]
+}
+
+[sub_resource type="Animation" id=2]
+resource_name = "transition"
+length = 0.6
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.4, 0.6 ),
+"transitions": PoolRealArray( 0.732043, 1.51572, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
+}
+tracks/1/type = "method"
+tracks/1/path = NodePath(".")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0.4 ),
+"transitions": PoolRealArray( 1 ),
+"values": [ {
+"args": [ "peaked" ],
+"method": "emit_signal"
+} ]
+}
 
 [node name="Game" type="Node"]
 script = ExtResource( 1 )
@@ -14,6 +61,7 @@ editor/display_folded = true
 layer = 100
 
 [node name="DebugDock" type="MarginContainer" parent="UI"]
+editor/display_folded = true
 anchor_bottom = 1.0
 margin_right = 440.0
 mouse_filter = 2
@@ -46,7 +94,22 @@ mouse_filter = 2
 reference_path = NodePath("../../../../../Game/Player/StateMachine")
 properties = PoolStringArray( "_state_name" )
 
-[node name="Player" parent="." instance=ExtResource( 5 )]
+[node name="Transition" type="ColorRect" parent="UI"]
+pause_mode = 2
+editor/display_folded = true
+modulate = Color( 1, 1, 1, 0 )
+margin_right = 1920.0
+margin_bottom = 1080.0
+mouse_filter = 2
+color = Color( 0, 0, 0, 1 )
+script = ExtResource( 5 )
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="UI/Transition"]
+autoplay = "<BASE>"
+anims/<BASE> = SubResource( 1 )
+anims/transition = SubResource( 2 )
+
+[node name="Player" parent="." instance=ExtResource( 6 )]
 editor/display_folded = true
 
 [editable path="Player"]

--- a/hook!-full-game/src/Player/Player.gd
+++ b/hook!-full-game/src/Player/Player.gd
@@ -27,7 +27,6 @@ var info_dict: = {} setget set_info_dict
 
 
 func _ready() -> void:
-	Events.connect("level_loaded", self, "_on_Events_level_loaded")
 	stats.connect("health_depleted", state_machine, "transition_to", ['Die'])
 
 

--- a/hook!-full-game/src/UI/Transition.gd
+++ b/hook!-full-game/src/UI/Transition.gd
@@ -1,0 +1,6 @@
+extends ColorRect
+
+
+signal peaked
+
+onready var animation_player: AnimationPlayer = $AnimationPlayer


### PR DESCRIPTION
I took a bit of a simpler aproach, no shaders or anything fancy like
that. Just a good old ColorRect that fades to black & back.

It works like this: when the Exit "portal" detects the player it
calls LevelLoader.trigger which takes care of everything:
- scene tree pause/unpause
- stuff is managed with yield: we wait until the transition emits a
  signal at its peak (100% opacity), at which time the function
  continues execution adding the level + player under the game node,
  then the scene tree unpauses and that's pretty much it

closes #98 

*edit*: ah, I also cleaned up some stuff a bit, for example level_loaded
signal from Events wasn't used anywhere and it was connected to a
non-existing function in Player, I removed that code to keep things tidy
(it's easy to add it back when we need it, otherwise we risk forgetting
"dead" code around)