### PR TITLE
Get states to manage their own signal connections in enter/exit

### DIFF
--- a/game/src/Main/StateMachine/State.gd
+++ b/game/src/Main/StateMachine/State.gd
@@ -14,17 +14,7 @@ var _state_machine: Node = null
 
 
 func _ready() -> void:
-	owner.connect("ready", self, "_setup")
 	_state_machine = _get_state_machine(self)
-
-
-"""
-Virtual function similar to Godot's built-in `_ready`,
-except that the callback happens once the node's owner is ready
-Use this to initialize the state with its owner's properties or to connect to the owner's signals
-"""
-func _setup() -> void:
-	pass
 
 
 func unhandled_input(event: InputEvent) -> void:

--- a/game/src/Main/StateMachine/StateMachine.gd
+++ b/game/src/Main/StateMachine/StateMachine.gd
@@ -17,6 +17,7 @@ func _init() -> void:
 
 
 func _ready() -> void:
+	yield(owner, "ready")
 	state.enter()
 
 

--- a/game/src/Player/Hook/States/Fire.gd
+++ b/game/src/Player/Hook/States/Fire.gd
@@ -1,15 +1,17 @@
 extends State
 
 
-func _setup() -> void:
-	owner.cooldown.connect("timeout", self, "_on_Cooldown_timeout")
-
-
 func _on_Cooldown_timeout() -> void:
 	_state_machine.transition_to("Aim")
 
 
+func physics_process(delta: float) -> void:
+	get_parent().physics_process(delta)
+
+
 func enter(msg: Dictionary = {}) -> void:
+	owner.cooldown.connect("timeout", self, "_on_Cooldown_timeout")
+	
 	owner.is_aiming = false
 	owner.cooldown.start()
 
@@ -23,7 +25,6 @@ func enter(msg: Dictionary = {}) -> void:
 	owner.emit_signal("hooked_onto_target", owner.get_target_position())
 
 
-func physics_process(delta: float) -> void:
-	get_parent().physics_process(delta)
-
-
+func exit() -> void:
+	owner.cooldown.disconnect("timeout", self, "_on_Cooldown_timeout")
+	

--- a/game/src/Player/States/Air.gd
+++ b/game/src/Player/States/Air.gd
@@ -20,21 +20,6 @@ onready var controls_freeze: Timer = $ControlsFreeze
 export var acceleration_x: = 5000.0
 
 
-func enter(msg: Dictionary = {}) -> void:
-	var move: = get_parent()
-	move.acceleration.x = acceleration_x
-	if "velocity" in msg:
-		move.velocity = msg.velocity 
-		move.max_speed.x = max(abs(msg.velocity.x), move.max_speed.x)
-	if "impulse" in msg:
-		move.velocity += calculate_jump_velocity(msg.impulse)
-	if "wall_jump" in msg:
-		controls_freeze.start()
-		move.acceleration = Vector2(acceleration_x, move.acceleration_default.y)
-		move.max_speed.x = max(abs(move.velocity.x), move.max_speed_default.x)
-		jump_delay.start()
-
-
 func unhandled_input(event: InputEvent) -> void:
 	var move: = get_parent()
 	# Jump after falling off a ledge
@@ -72,9 +57,27 @@ func physics_process(delta: float) -> void:
 		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": move.velocity})
 
 
+func enter(msg: Dictionary = {}) -> void:
+	var move: = get_parent()
+	move.enter(msg)
+	
+	move.acceleration.x = acceleration_x
+	if "velocity" in msg:
+		move.velocity = msg.velocity 
+		move.max_speed.x = max(abs(msg.velocity.x), move.max_speed.x)
+	if "impulse" in msg:
+		move.velocity += calculate_jump_velocity(msg.impulse)
+	if "wall_jump" in msg:
+		controls_freeze.start()
+		move.acceleration = Vector2(acceleration_x, move.acceleration_default.y)
+		move.max_speed.x = max(abs(move.velocity.x), move.max_speed_default.x)
+		jump_delay.start()
+
+
 func exit() -> void:
 	var move: = get_parent()
 	move.acceleration = move.acceleration_default
+	move.exit()
 
 
 """

--- a/game/src/Player/States/Debug.gd
+++ b/game/src/Player/States/Debug.gd
@@ -11,10 +11,6 @@ var velocity: = Vector2.ZERO
 const speed: = Vector2(600.0, 600.0)
 
 
-func enter(msg: Dictionary = {}):
-	owner.is_active = false
-
-
 func unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed('toggle_debug_move'):
 		_state_machine.transition_to('Move/Air', {'velocity': Vector2.ZERO})
@@ -28,6 +24,10 @@ func physics_process(delta: float) -> void:
 	velocity = speed * direction * multiplier
 	owner.position += velocity * delta
 	Events.emit_signal("player_moved", owner)
+
+
+func enter(msg: Dictionary = {}):
+	owner.is_active = false
 
 
 func exit():

--- a/game/src/Player/States/Die.gd
+++ b/game/src/Player/States/Die.gd
@@ -4,6 +4,10 @@ extends State
 var last_checkpoint: Area2D = null
 
 
+func _on_Player_animation_finished(anim_name: String) -> void:
+	_state_machine.transition_to('Spawn', {last_checkpoint = last_checkpoint})
+
+
 func enter(msg: Dictionary = {}) -> void:
 	assert "last_checkpoint" in msg
 	last_checkpoint = msg.last_checkpoint
@@ -14,7 +18,3 @@ func enter(msg: Dictionary = {}) -> void:
 
 func exit() -> void:
 	owner.skin.disconnect("animation_finished", self, "_on_Player_animation_finished")
-
-
-func _on_Player_animation_finished(anim_name: String) -> void:
-	_state_machine.transition_to('Spawn', {last_checkpoint = last_checkpoint})

--- a/game/src/Player/States/Hook.gd
+++ b/game/src/Player/States/Hook.gd
@@ -13,13 +13,6 @@ var target_global_position: = Vector2(INF, INF)
 var velocity: = Vector2.ZERO
 
 
-func enter(msg: Dictionary = {}) -> void:
-	match msg:
-		{"target_global_position": var tgp, "velocity": var v}:
-			target_global_position = tgp
-			velocity = v
-
-
 func physics_process(delta: float) -> void:
 	var new_velocity: = Steering.arrive_to(
 		velocity,
@@ -37,6 +30,13 @@ func physics_process(delta: float) -> void:
 	if distance < velocity.length() * delta:
 		velocity = velocity.normalized() * arrive_push
 		_state_machine.transition_to("Move/Air", {velocity = velocity})
+
+
+func enter(msg: Dictionary = {}) -> void:
+	match msg:
+		{"target_global_position": var tgp, "velocity": var v}:
+			target_global_position = tgp
+			velocity = v
 
 
 func exit() -> void:

--- a/game/src/Player/States/Idle.gd
+++ b/game/src/Player/States/Idle.gd
@@ -5,12 +5,8 @@ extends State
 onready var jump_delay: Timer = $JumpDelay
 
 
-func enter(msg: Dictionary = {}) -> void:
-	var move = get_parent()
-	move.max_speed = move.max_speed_default
-	move.velocity = Vector2.ZERO
-	if jump_delay.time_left > 0.0:
-		_state_machine.transition_to("Move/Air")
+func _get_configuration_warning() -> String:
+	return "" if $JumpDelay else "%s requires a Timer child named JumpDelay" % name
 
 
 func unhandled_input(event: InputEvent) -> void:
@@ -26,5 +22,15 @@ func physics_process(delta: float) -> void:
 		_state_machine.transition_to("Move/Air")
 
 
-func _get_configuration_warning() -> String:
-	return "" if $JumpDelay else "%s requires a Timer child named JumpDelay" % name
+func enter(msg: Dictionary = {}) -> void:
+	var move = get_parent()
+	move.enter(msg)
+	
+	move.max_speed = move.max_speed_default
+	move.velocity = Vector2.ZERO
+	if jump_delay.time_left > 0.0:
+		_state_machine.transition_to("Move/Air")
+
+
+func exit() -> void:
+	get_parent().exit()

--- a/game/src/Player/States/Ledge.gd
+++ b/game/src/Player/States/Ledge.gd
@@ -4,10 +4,6 @@ Pulls the character up a ledge, temporarily taking control away from the player
 """
 
 
-func _setup() -> void:
-	owner.skin.connect("animation_finished", self, "_on_Skin_animation_finished")
-
-
 func _on_Skin_animation_finished(name: String) -> void:
 	if name == "ledge":
 		_state_machine.transition_to("Move/Run")
@@ -15,10 +11,16 @@ func _on_Skin_animation_finished(name: String) -> void:
 
 func enter(msg: Dictionary = {}) -> void:
 	assert "move_state" in msg and msg.move_state is State
-
+	
+	owner.skin.connect("animation_finished", self, "_on_Skin_animation_finished")
+	
 	var start: Vector2 = owner.global_position
 	var ld = owner.ledge_detector
 	owner.global_position = ld.get_top_global_position() + ld.get_cast_to_directed()
 	owner.global_position = owner.floor_detector.get_floor_position()
 	msg.move_state.velocity.y = 0.0
 	owner.skin.play('ledge', {from = start - owner.global_position})
+
+
+func exit() -> void:
+	owner.skin.disconnect("animation_finished", self, "_on_Skin_animation_finished")

--- a/game/src/Player/States/Move.gd
+++ b/game/src/Player/States/Move.gd
@@ -15,12 +15,6 @@ var max_speed: = max_speed_default
 var velocity: = Vector2.ZERO
 
 
-func _setup() -> void:
-	owner.hook.connect("hooked_onto_target", self, "_on_Hook_hooked_onto_target")
-	$Air.connect("jumped", $Idle.jump_delay, "start")
-	owner.stats.connect("damage_taken", self, "_on_Stats_damage_taken")
-	owner.pass_through.connect("body_exited", self, "_on_PassThrough_body_exited")
-
 func _on_Hook_hooked_onto_target(target_global_position: Vector2) -> void:
 	var to_target: Vector2 = target_global_position - owner.global_position
 	if owner.is_on_floor() and to_target.y > 0.0:
@@ -55,6 +49,20 @@ func physics_process(delta: float) -> void:
 	velocity = calculate_velocity(velocity, max_speed, acceleration, delta, get_move_direction())
 	velocity = owner.move_and_slide(velocity, owner.FLOOR_NORMAL)
 	Events.emit_signal("player_moved", owner)
+
+
+func enter(msg: Dictionary = {}) -> void:
+	owner.hook.connect("hooked_onto_target", self, "_on_Hook_hooked_onto_target")
+	owner.stats.connect("damage_taken", self, "_on_Stats_damage_taken")
+	owner.pass_through.connect("body_exited", self, "_on_PassThrough_body_exited")
+	$Air.connect("jumped", $Idle.jump_delay, "start")
+
+
+func exit() -> void:
+	owner.hook.disconnect("hooked_onto_target", self, "_on_Hook_hooked_onto_target")
+	owner.stats.disconnect("damage_taken", self, "_on_Stats_damage_taken")
+	owner.pass_through.disconnect("body_exited", self, "_on_PassThrough_body_exited")
+	$Air.disconnect("jumped", $Idle.jump_delay, "start")
 
 
 static func calculate_velocity(

--- a/game/src/Player/States/Run.gd
+++ b/game/src/Player/States/Run.gd
@@ -20,3 +20,11 @@ func physics_process(delta: float) -> void:
 	else:
 		_state_machine.transition_to("Move/Air")
 	move.physics_process(delta)
+
+
+func enter(msg: Dictionary = {}) -> void:
+	get_parent().enter(msg)
+
+
+func exit() -> void:
+	get_parent().exit()

--- a/game/src/Player/States/Spawn.gd
+++ b/game/src/Player/States/Spawn.gd
@@ -4,6 +4,10 @@ Takes control away from the player and makes the character spawn
 """
 
 
+func _on_Player_animation_finished(anim_name: String) -> void:
+	_state_machine.transition_to('Move/Idle')
+
+
 func enter(msg: Dictionary = {}) -> void:
 	assert "last_checkpoint" in msg
 	owner.global_position = msg.last_checkpoint.global_position
@@ -17,7 +21,3 @@ func exit() -> void:
 	owner.is_active = true
 	owner.camera_rig.is_active = true
 	owner.skin.disconnect("animation_finished", self, "_on_Player_animation_finished")
-
-
-func _on_Player_animation_finished(anim_name: String) -> void:
-	_state_machine.transition_to('Move/Idle')

--- a/game/src/Player/States/Wall.gd
+++ b/game/src/Player/States/Wall.gd
@@ -14,14 +14,6 @@ var _wall_normal: = -1
 var _velocity: = Vector2.ZERO
 
 
-func enter(msg: Dictionary = {}) -> void:
-	_wall_normal = msg.normal
-	_velocity.y = clamp(msg.velocity.y, -max_slide_speed, max_slide_speed)
-
-	owner.wall_detector.cast_to.x = abs(owner.wall_detector.cast_to.x) * -1.0 * sign(_wall_normal)
-	owner.wall_detector.enabled = true
-
-
 func unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("jump"):
 		jump()
@@ -44,8 +36,19 @@ func physics_process(delta: float) -> void:
 		_state_machine.transition_to("Move/Air")
 
 
+func enter(msg: Dictionary = {}) -> void:
+	get_parent().enter(msg)
+	
+	_wall_normal = msg.normal
+	_velocity.y = clamp(msg.velocity.y, -max_slide_speed, max_slide_speed)
+
+	owner.wall_detector.cast_to.x = abs(owner.wall_detector.cast_to.x) * -1.0 * sign(_wall_normal)
+	owner.wall_detector.enabled = true
+
+
 func exit() -> void:
 	owner.wall_detector.enabled = false
+	get_parent().exit()
 
 
 func jump() -> void:


### PR DESCRIPTION
Each state will now manage its own signal connections within enter/exit functions.

- we don't need `_setup` function from `State.gd` any longer with this approach. But since we were setting things up in `_setup`, dependent on the `owner` being ready, we force the `StateMachine` to wait for the owner to be ready before entering the first state: `yield(owner, "_ready")`
- I've also reordered all functions within states to the same order in `State.gd`:
  1. Godot virtual functions
  1. `unhandled_input`
  1. `physics_process`
  1. `enter`
  1. `exit`
  1. extra (public) functions
- with this approach, we either have to copy code in each `enter`/`exit` nested states if necessary or have to call the parent `enter`/`exit` functions always if connections are made within the parent. I've chosen the latter approach, eg. `get_parent().enter(msg)`/`get_parent().exit()`

closes #152 