### PR TITLE
Replace get_parent() calls with _parent var

### DIFF
--- a/game/src/Main/StateMachine/State.gd
+++ b/game/src/Main/StateMachine/State.gd
@@ -3,12 +3,19 @@ class_name State
 """
 State interface to use in Hierarchical State Machines.
 The lowest leaf tries to handle callbacks, and if it can't, it delegates the work to its parent.
-It's up to the user to call the parent state's functions, e.g. `get_parent().physics_process(delta)`
+It's up to the user to call the parent state's functions, e.g. `_parent.physics_process(delta)`
 Use State as a child of a StateMachine node.
 """
 
 
 onready var _state_machine: = _get_state_machine(self)
+
+var _parent: Node = null
+
+
+func _ready() -> void:
+	yield(owner, "ready")
+	_parent = get_parent()
 
 
 func unhandled_input(event: InputEvent) -> void:

--- a/game/src/Player/Hook/States/Fire.gd
+++ b/game/src/Player/Hook/States/Fire.gd
@@ -6,7 +6,7 @@ func _on_Cooldown_timeout() -> void:
 
 
 func physics_process(delta: float) -> void:
-	get_parent().physics_process(delta)
+	_parent.physics_process(delta)
 
 
 func enter(msg: Dictionary = {}) -> void:

--- a/game/src/Player/States/Air.gd
+++ b/game/src/Player/States/Air.gd
@@ -21,65 +21,60 @@ export var acceleration_x: = 5000.0
 
 
 func unhandled_input(event: InputEvent) -> void:
-	var move: = get_parent()
 	# Jump after falling off a ledge
 	if event.is_action_pressed("jump"):
-		if move.velocity.y >= 0.0 and jump_delay.time_left > 0.0:
-			move.velocity = calculate_jump_velocity(move.jump_impulse)
+		if _parent.velocity.y >= 0.0 and jump_delay.time_left > 0.0:
+			_parent.velocity = calculate_jump_velocity(_parent.jump_impulse)
 		emit_signal("jumped")
 	else:
-		move.unhandled_input(event)
+		_parent.unhandled_input(event)
 
 
 func physics_process(delta: float) -> void:
-	var move: = get_parent()
-	move.physics_process(delta)
+	_parent.physics_process(delta)
 	Events.emit_signal("player_moved", owner)
 
 	# Landing
 	if owner.is_on_floor():
-		var target_state: = "Move/Idle" if move.get_move_direction().x == 0 else "Move/Run"
+		var target_state: = "Move/Idle" if _parent.get_move_direction().x == 0 else "Move/Run"
 		_state_machine.transition_to(target_state)
 
 	elif owner.ledge_wall_detector.is_against_ledge():
-		_state_machine.transition_to("Ledge", {move_state = move})
+		_state_machine.transition_to("Ledge", {move_state = _parent})
 
 	if owner.is_on_wall():
 		var wall_normal: float = owner.get_slide_collision(0).normal.x
-		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": move.velocity})
+		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": _parent.velocity})
 
 
 func enter(msg: Dictionary = {}) -> void:
-	var move: = get_parent()
-	move.enter(msg)
+	_parent.enter(msg)
 	
-	move.acceleration.x = acceleration_x
+	_parent.acceleration.x = acceleration_x
 	if "velocity" in msg:
-		move.velocity = msg.velocity 
-		move.max_speed.x = max(abs(msg.velocity.x), move.max_speed.x)
+		_parent.velocity = msg.velocity 
+		_parent.max_speed.x = max(abs(msg.velocity.x), _parent.max_speed.x)
 	if "impulse" in msg:
-		move.velocity += calculate_jump_velocity(msg.impulse)
+		_parent.velocity += calculate_jump_velocity(msg.impulse)
 	if "wall_jump" in msg:
 		controls_freeze.start()
-		move.acceleration = Vector2(acceleration_x, move.acceleration_default.y)
-		move.max_speed.x = max(abs(move.velocity.x), move.max_speed_default.x)
+		_parent.acceleration = Vector2(acceleration_x, _parent.acceleration_default.y)
+		_parent.max_speed.x = max(abs(_parent.velocity.x), _parent.max_speed_default.x)
 		jump_delay.start()
 
 
 func exit() -> void:
-	var move: = get_parent()
-	move.acceleration = move.acceleration_default
-	move.exit()
+	_parent.acceleration = _parent.acceleration_default
+	_parent.exit()
 
 
 """
 Returns a new velocity with a vertical impulse applied to it
 """
 func calculate_jump_velocity(impulse: float = 0.0) -> Vector2:
-	var move: State = get_parent()
-	return move.calculate_velocity(
-		move.velocity,
-		move.max_speed,
+	return _parent.calculate_velocity(
+		_parent.velocity,
+		_parent.max_speed,
 		Vector2(0.0, impulse),
 		1.0,
 		Vector2.UP

--- a/game/src/Player/States/Idle.gd
+++ b/game/src/Player/States/Idle.gd
@@ -10,27 +10,24 @@ func _get_configuration_warning() -> String:
 
 
 func unhandled_input(event: InputEvent) -> void:
-	var move = get_parent()
-	move.unhandled_input(event)
+	_parent.unhandled_input(event)
 
 
 func physics_process(delta: float) -> void:
-	var move: = get_parent()
-	if owner.is_on_floor() and move.get_move_direction().x != 0.0:
+	if owner.is_on_floor() and _parent.get_move_direction().x != 0.0:
 		_state_machine.transition_to("Move/Run")
 	elif not owner.is_on_floor():
 		_state_machine.transition_to("Move/Air")
 
 
 func enter(msg: Dictionary = {}) -> void:
-	var move = get_parent()
-	move.enter(msg)
+	_parent.enter(msg)
 	
-	move.max_speed = move.max_speed_default
-	move.velocity = Vector2.ZERO
+	_parent.max_speed = _parent.max_speed_default
+	_parent.velocity = Vector2.ZERO
 	if jump_delay.time_left > 0.0:
 		_state_machine.transition_to("Move/Air")
 
 
 func exit() -> void:
-	get_parent().exit()
+	_parent.exit()

--- a/game/src/Player/States/Run.gd
+++ b/game/src/Player/States/Run.gd
@@ -8,23 +8,21 @@ with state transitions
 
 
 func unhandled_input(event: InputEvent) -> void:
-	var move: = get_parent()
-	move.unhandled_input(event)
+	_parent.unhandled_input(event)
 
 
 func physics_process(delta: float) -> void:
-	var move: = get_parent()
 	if owner.is_on_floor():
-		if move.get_move_direction().x == 0.0:
+		if _parent.get_move_direction().x == 0.0:
 			_state_machine.transition_to("Move/Idle")
 	else:
 		_state_machine.transition_to("Move/Air")
-	move.physics_process(delta)
+	_parent.physics_process(delta)
 
 
 func enter(msg: Dictionary = {}) -> void:
-	get_parent().enter(msg)
+	_parent.enter(msg)
 
 
 func exit() -> void:
-	get_parent().exit()
+	_parent.exit()

--- a/game/src/Player/States/Wall.gd
+++ b/game/src/Player/States/Wall.gd
@@ -30,21 +30,20 @@ func physics_process(delta: float) -> void:
 	if owner.is_on_floor():
 		_state_machine.transition_to("Move/Idle")
 
-	var move: = get_parent()
-	var is_moving_away_from_wall: = sign(move.get_move_direction().x) == sign(_wall_normal)
+	var is_moving_away_from_wall: = sign(_parent.get_move_direction().x) == sign(_wall_normal)
 	if is_moving_away_from_wall or not owner.ledge_wall_detector.is_against_wall():
 		_state_machine.transition_to("Move/Air", {"velocity":_velocity})
 
 
 func enter(msg: Dictionary = {}) -> void:
-	get_parent().enter(msg)
+	_parent.enter(msg)
 
 	_wall_normal = msg.normal
 	_velocity.y = clamp(msg.velocity.y, -max_slide_speed, max_slide_speed)
 
 
 func exit() -> void:
-	get_parent().exit()
+	_parent.exit()
 
 
 func jump() -> void:


### PR DESCRIPTION
Instead of calling `get_parent()`, we replace it with a generic `_parent` "private" var which is initialized in all `State`-extending classes inside `_ready` after `yield(owner, "ready")`. This way it gets initialized automatically and available in all inheriting classes.